### PR TITLE
Fixup socket sharing to work correctly

### DIFF
--- a/bin/server-wrapper
+++ b/bin/server-wrapper
@@ -5,8 +5,10 @@
 #  -x	    print commands and their args as executed
 set -ex
 
-if [ -e $SNAP_DATA/socket ]; then
-    rm $SNAP_DATA/socket
+mkdir -p $SNAP_DATA/sockets
+
+if [ -e $SNAP_DATA/sockets/socket ]; then
+    rm $SNAP_DATA/sockets/socket
 fi
 
 $SNAP/bin/unix-domain-server $SNAP_DATA

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,8 +12,8 @@ confinement: strict
 slots:
   content:
     content: socket-directory
-    read:
-      - $SNAP_DATA
+    write:
+      - $SNAP_DATA/sockets
 
 apps:
   unix-domain-server:

--- a/unix_domain_server.go
+++ b/unix_domain_server.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	dir := os.Args[1]
-	path := dir + "/socket"
+	path := dir + "/sockets/socket"
 
 	fmt.Println("socket path is ", path)
 


### PR DESCRIPTION
If we don't mark the socket directory as writable place we will end up with an AppArmor denial

[39011.782933] audit: type=1400 audit(1482308479.420:453026): apparmor="DENIED" operation="connect" profile="snap.unix-domain-client.unix-domain-client" name="/var/snap/unix-domain-server/x1/sockdir/socket" pid=27197 comm="unix-domain-cli" requested_mask="w" denied_mask="w" fsuid=0 ouid=0

as using just 'read' doesn't give write permissions :-)